### PR TITLE
iopaint: reduce number of layers and remove apt cache

### DIFF
--- a/iopaint/Dockerfile
+++ b/iopaint/Dockerfile
@@ -1,15 +1,19 @@
 FROM python:3.10-slim
 
-RUN apt-get update && apt-get upgrade -y
-RUN pip3 install --upgrade pip
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip3 install --upgrade pip && \
+    addgroup --gid 1000 user && \
+    adduser --uid 1000 --gid 1000 user
 
-RUN addgroup --gid 1000 user && adduser --uid 1000 --gid 1000 user
 USER user
 ENV PATH="/home/user/.local/bin:${PATH}"
 
-RUN pip3 install torch==2.1.2 torchvision --extra-index-url https://download.pytorch.org/whl/cpu
-RUN pip3 install iopaint
-RUN iopaint install-plugins-packages
+RUN pip3 install torch==2.1.2 torchvision --extra-index-url https://download.pytorch.org/whl/cpu && \
+    pip3 install iopaint && \
+    iopaint install-plugins-packages
 
 EXPOSE 8080
 


### PR DESCRIPTION
reduces the image size a bit, by 0.17 GB

```
$ docker images 
REPOSITORY                     TAG       IMAGE ID       CREATED          SIZE                                                                                                                                                                                 
strubbl_iopaint                latest    5565aa15c0e3   2 minutes ago    2.6GB
<none>                         <none>    2967844040b9   4 minutes ago   2.77GB
```
